### PR TITLE
allow quantity formula to accept text

### DIFF
--- a/src/templates/sheet/brt-roll-table-config.hbs
+++ b/src/templates/sheet/brt-roll-table-config.hbs
@@ -363,25 +363,25 @@
                             name="results.{{i}}.flags.better-rolltables.brt-result-formula.formula"
                             value="{{result.flags.better-rolltables.brt-result-formula.formula}}"
                             placeholder="1"
-                            data-dtype="Number"
+                            data-dtype="String"
                         />
 					{{else if result.isDocument}}
                         <input {{#brt-isEmpty result.flags.better-rolltables.brt-result-formula.formula}} style="background: lightcoral;"{{/brt-isEmpty}} 
                             class="result-better-rolltables-formula"
-                            type="number" min="1"
+                            type="text"
                             name="results.{{i}}.flags.better-rolltables.brt-result-formula.formula"
                             value="{{result.flags.better-rolltables.brt-result-formula.formula}}"
                             placeholder="1"
-                            data-dtype="Number"
+                            data-dtype="String"
                             />
 					{{else if result.isCompendium}}
                         <input {{#brt-isEmpty result.flags.better-rolltables.brt-result-formula.formula}} style="background: lightcoral;"{{/brt-isEmpty}} 
                             class="result-better-rolltables-formula"
-                            type="number" min="1"
+                            type="text"
                             name="results.{{i}}.flags.better-rolltables.brt-result-formula.formula"
                             value="{{result.flags.better-rolltables.brt-result-formula.formula}}"
                             placeholder="1"
-                            data-dtype="Number"
+                            data-dtype="String"
                             />
 					{{/if}}
                 </td>


### PR DESCRIPTION
The translation over the quantity header says:
"resultQuantityHeaderHint": "Sets the amount of elements associated with the individual result, for systems that have been supported. Also accepts roll formulas such as '1d10'",

But the input fields only accepted Numbers. I changed them so it accepts text, it seems to work fine on my end.