### PR TITLE
Show quantity after text result in chat

### DIFF
--- a/src/templates/card/better-chat-card.hbs
+++ b/src/templates/card/better-chat-card.hbs
@@ -18,7 +18,7 @@
                     {{else}}
                         <li class="table-result flexrow" data-result-id="{{ itemData.item._id }}" data-result-uuid="">
                             <img class="result-image" src="{{itemData.item.img}}">
-                            <div class="result-text">{{{itemData.item.text}}}</div>
+                            <div class="result-text">{{{itemData.item.text}}}{{#ifgt itemData.quantity 1 }}<strong>&nbsp; &#xD7; {{itemData.quantity}}</strong>{{/ifgt}}</div>
                         </li>
                     {{/if}}
                 {{/case}}

--- a/src/templates/card/harvest-chat-card.hbs
+++ b/src/templates/card/harvest-chat-card.hbs
@@ -33,7 +33,7 @@
                     {{else}}
                         <li class="table-result flexrow" data-result-id="{{ itemData.item._id }}" data-result-uuid="">
                             <img class="result-image" src="{{itemData.item.img}}">
-                            <div class="result-text">{{{itemData.item.text}}}</div>
+                            <div class="result-text">{{{itemData.item.text}}}{{#ifgt itemData.quantity 1 }}<strong>&nbsp; &#xD7; {{itemData.quantity}}</strong>{{/ifgt}}</div>
                         </li>
                     {{/if}}
                 {{/case}}

--- a/src/templates/card/loot-chat-card.hbs
+++ b/src/templates/card/loot-chat-card.hbs
@@ -33,7 +33,7 @@
                     {{else}}
                         <li class="table-result flexrow" data-result-id="{{ itemData.item._id }}" data-result-uuid="">
                             <img class="result-image" src="{{itemData.item.img}}">
-                            <div class="result-text">{{{itemData.item.text}}}</div>
+                            <div class="result-text">{{{itemData.item.text}}}{{#ifgt itemData.quantity 1 }}<strong>&nbsp; &#xD7; {{itemData.quantity}}</strong>{{/ifgt}}</div>
                         </li>
                     {{/if}}
                 {{/case}}


### PR DESCRIPTION
The number of times a text result is rolled in a table is stored in the item data, for some reason it was not displayed. Closes #23 